### PR TITLE
Support ddtrace 1.x

### DIFF
--- a/lib/opencensus/trace/exporters/datadog/converter.rb
+++ b/lib/opencensus/trace/exporters/datadog/converter.rb
@@ -1,5 +1,3 @@
-require 'ddtrace/version'
-
 require 'datadog/tracing/metadata/ext'
 require 'datadog/tracing/sampling/ext'
 

--- a/lib/opencensus/trace/exporters/datadog/converter.rb
+++ b/lib/opencensus/trace/exporters/datadog/converter.rb
@@ -1,13 +1,7 @@
 require 'ddtrace/version'
 
-if Gem::Version.new('1.0.0') <= Gem::Version.new(DDTrace::VERSION::STRING)
-  require 'datadog/tracing/metadata/ext'
-  require 'datadog/tracing/sampling/ext'
-else
-  require 'ddtrace/ext/distributed'
-  require 'ddtrace/ext/priority'
-  require 'ddtrace/ext/errors'
-end
+require 'datadog/tracing/metadata/ext'
+require 'datadog/tracing/sampling/ext'
 
 module OpenCensus
   module Trace
@@ -20,11 +14,7 @@ module OpenCensus
           DATADOG_SPAN_TYPE_KEY = 'span.type'.freeze
           DATADOG_SERVICE_NAME_KEY = 'service.name'.freeze
           DATADOG_RESOURCE_NAME_KEY = 'resource.name'.freeze
-          DATADOG_SAMPLING_PRIORITY_KEY = if defined?(::Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY)
-            ::Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY
-          else
-            ::Datadog::Ext::DistributedTracing::SAMPLING_PRIORITY_KEY
-          end
+          DATADOG_SAMPLING_PRIORITY_KEY = ::Datadog::Tracing::Metadata::Ext::Distributed::TAG_SAMPLING_PRIORITY
 
           STATUS_DESCRIPTION_KEY = 'opencensus.status_description'.freeze
 
@@ -68,11 +58,7 @@ module OpenCensus
               duration: ((span.end_time.to_f - span.start_time.to_f) * 1e9).to_i,
             }
 
-            dd_span[:metrics][DATADOG_SAMPLING_PRIORITY_KEY] = if defined?(::Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP)
-              ::Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP
-            else
-              ::Datadog::Ext::Priority::AUTO_KEEP
-            end
+            dd_span[:metrics][DATADOG_SAMPLING_PRIORITY_KEY] = ::Datadog::Tracing::Sampling::Ext::Priority::AUTO_KEEP
 
             convert_status(dd_span, span.status)
 
@@ -107,11 +93,7 @@ module OpenCensus
             status_key = STATUS_DESCRIPTION_KEY
             return if status.nil?
             if status.code != 0 then
-              status_key = if defined?(::Datadog::Tracing::Metadata::Ext::Errors::TAG_MSG)
-                ::Datadog::Tracing::Metadata::Ext::Errors::TAG_MSG
-              else
-                ::Datadog::Ext::Errors::MSG
-              end
+              status_key = ::Datadog::Tracing::Metadata::Ext::Errors::TAG_MSG
               dd_span[:error] = 1
               code = status.code.to_i
               return if code < 0 || code >= CANONICAL_CODES.length

--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'msgpack'
   spec.add_dependency 'opencensus'
-  spec.add_dependency 'ddtrace', '< 2.0'
+  spec.add_dependency 'ddtrace', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'msgpack'
   spec.add_dependency 'opencensus'
-  spec.add_dependency 'ddtrace', '< 1.0'
+  spec.add_dependency 'ddtrace', '< 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## Why

ddtrace 0.x doesn't support Ruby 3.2.
https://github.com/DataDog/dd-trace-rb/blob/9fd04441f91f4668c6d31dcff2af2115b38318c0/lib/ddtrace/version.rb#L13-L23

## What

Support ddtrace 1.x.