### PR TITLE
Add Ruby 2.7, 3.0, 3.1 and drop 2.3, 2.4, 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-before_install: gem install bundler -v 1.16.2
+  - 2.7
+  - 3.0
+  - 3.1
 script:
   - bundle exec rspec

--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opencensus'
   spec.add_dependency 'ddtrace', '< 1.0'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
## Why

Ruby 2.3, 2.4 and 2.5 are no longer supported.

## What

Update `.travis.yml` to test with Ruby 2.7, 3.0 and 3.1.